### PR TITLE
fixed missing request params for case of unknown query

### DIFF
--- a/influx_prompt/influx_client.py
+++ b/influx_prompt/influx_client.py
@@ -103,7 +103,11 @@ class Client(object):
             return {
                 'method': 'POST',
                 'url': "{0}/{1}".format(self._baseurl, 'query'),
+                'auth': (self.username, self.password),
                 'params': params,
+                'headers': self._headers,
+                'verify': self.verify_ssl,
+                'timeout': self.timeout,
             }
 
         return {


### PR DESCRIPTION
Without these missing request params program breaks and it is easily reproducible: 
1. connect to InfluxDB with valid credentials
2. type `sel`
3. hit ENTER (do not use autocompletion)

Result: program breaks, in my case, when using Self Signed SSL Cert:
```
  File "/usr/local/lib/python3.7/site-packages/urllib3/util/retry.py", line 388, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='influxdb.', port=8086): Max retries exceeded with url: /query?q=sele&db=stats (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate (_ssl.c:1045)')))
```