### PR TITLE
hiding 'InsecureRequestWarning: Unverified HTTPS request is being made'

### DIFF
--- a/influx_prompt/influx_client.py
+++ b/influx_prompt/influx_client.py
@@ -18,6 +18,7 @@ class Client(object):
         self.database = args['database']
         self.ssl = args['ssl']
         self.verify_ssl = args['ssl_cert']
+        self.hide_invalid_ssl_warnings = args['hide_invalid_ssl_warnings']
         self.timeout = args['timeout']
         self.retries = args['retry']
         self._session = requests.Session()
@@ -40,6 +41,8 @@ class Client(object):
         _try = 0
         while retry:
             try:
+                if self.hide_invalid_ssl_warnings:
+                    requests.packages.urllib3.disable_warnings()
                 response = self._session.request(**request_args)
                 break
             except (requests.exceptions.ConnectionError,
@@ -61,6 +64,10 @@ class Client(object):
 
     def ping(self):
         url = "{0}/{1}".format(self._baseurl, 'ping')
+
+        if self.hide_invalid_ssl_warnings:
+            requests.packages.urllib3.disable_warnings()
+
         requests.head(url, verify=self.verify_ssl)
 
     def _make_request_args(self, q, database, epoch):

--- a/influx_prompt/main.py
+++ b/influx_prompt/main.py
@@ -151,6 +151,9 @@ def cli():
     parser.add_argument("--ssl-cert", action='store_true',
                         help="verify SSL certificates for HTTPS requests "
                         "(Default=False)")
+    parser.add_argument("--hide-invalid-ssl-warnings", action='store_true',
+                        help="hide warnings for invalid SSL certificate for HTTPS requests "
+                        "(Default=False)")
     parser.add_argument("--timeout",
                         help="number of seconds Requests will "
                         "wait for your client to establish a connection "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import pytest
 from .utils import (
     HOST, USER, PASSWORD, PORT,
     DATABASE, SSL, SSLCERT, TIMEOUT, RETRY,
+    HIDE_INVALID_SSL_WARNINGS,
 )
 
 
@@ -18,4 +19,5 @@ def default_args():
         'ssl_cert': SSLCERT,
         'timeout': TIMEOUT,
         'retry': RETRY,
+        'hide_invalid_ssl_warnings': HIDE_INVALID_SSL_WARNINGS,
     }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -53,11 +53,19 @@ class MockRequest(object):
 def client(default_args):
     return Client(default_args)
 
+@pytest.fixture
+def client_ssl_warning_hidden(default_args):
+    default_args["hide_invalid_ssl_warnings"] = True
+    return Client(default_args)
+
 
 def test_ping(client):
     client.ping()
     assert True
 
+def test_ping_ssl_warning_hidden(client_ssl_warning_hidden):
+    client_ssl_warning_hidden.ping()
+    assert True
 
 def test_insert(client):
     client.query('INSERT mymeas,mytag=12 myfield=91 1434055562000000000',
@@ -149,6 +157,16 @@ def test_exceed_retry(mock_request, client):
 
 def test_unknown_query(client):
     result = client.query('I AM RPING, I COME FROM TAIWAN.')
+    assert result == {
+        'error': 'error parsing query: '
+                 'found I, expected SELECT, DELETE, SHOW, CREATE, DROP, '
+                 'EXPLAIN, GRANT, REVOKE, ALTER, SET, KILL '
+                 'at line 1, char 1'
+    }
+
+
+def test_unknown_query_ssl_warning_hidden(client_ssl_warning_hidden):
+    result = client_ssl_warning_hidden.query('I AM RPING, I COME FROM TAIWAN.')
     assert result == {
         'error': 'error parsing query: '
                  'found I, expected SELECT, DELETE, SHOW, CREATE, DROP, '

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,6 +11,7 @@ SSL = os.getenv('PYTEST_SSL', False)
 SSLCERT = os.getenv('PYTEST_SSLCERT', False)
 TIMEOUT = os.getenv('PYTEST_TIMEOUT', None)
 RETRY = os.getenv('PYTEST_RETRY', 3)
+HIDE_INVALID_SSL_WARNINGS = os.getenv('PYTEST_HIDE_INVALID_SSL_WARNINGS', False)
 
 
 def ping():


### PR DESCRIPTION
added param for hiding annoying 'InsecureRequestWarning: Unverified HTTPS request is being made' request warnings, when using known and trusted self-signed certificate:
```
InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
```