### PR TITLE
fixed cannot set the database correctly when including any symbol

### DIFF
--- a/influx_prompt/extra_command.py
+++ b/influx_prompt/extra_command.py
@@ -3,7 +3,7 @@ import re
 
 
 def process_extra_command(args, query):
-    use_pattern = re.compile(r"use\s(?P<database>\w+);?", re.IGNORECASE)
+    use_pattern = re.compile(r"use\s(?P<database>\S+);?", re.IGNORECASE)
     m = use_pattern.match(query)
     if m:
         database = m.group('database')


### PR DESCRIPTION
It seems `influx-prompt` cannot set the database correctly when including any symbol(e.g. "-", ":") in the database name.
```
> influx-prompt
Version: 0.1.2
Welcome!
Any issue please post to https://github.com/RPing/influx-prompt/issues
[Warning] You havn't set database. use "use <database>" to specify database.
root> show databases
name: databases
name
---
_internal
test-test
test:test

root> use test-test
database now set to test <-!!
root> use test:test
database now set to test <-!!
```

But `influxdb-client` can set the database correctly when including any symbol in the database name.
```
> influx
Connected to http://localhost:8086 version 1.8.2
InfluxDB shell version: 1.8.2
> show databases
name: databases
name
----
_internal
test-test
test:test

> use test-test
Using database test-test
> use test:test
Using database test:test
```

I fixed the above issue.
