### PR TITLE
Gracefully handle empty series result

### DIFF
--- a/influx_prompt/tabular.py
+++ b/influx_prompt/tabular.py
@@ -17,7 +17,7 @@ def json_to_tabular_result(j):
             continue
 
         rr = jsane.from_dict(r)
-        series_list = rr.series.r(default=None)
+        series_list = rr.series.r(default=[])
 
         for series in series_list:
             name = series.get('name')

--- a/tests/test_tabular.py
+++ b/tests/test_tabular.py
@@ -192,3 +192,13 @@ def test_multiple_series_json():
         ('', '\n'),
         ('', '\n'),
     ]
+
+
+def test_no_result():
+    j = {
+        'results': [{
+            'statement_id': 0
+        }]
+    }
+    result = json_to_tabular_result(j)
+    assert result == []


### PR DESCRIPTION
An invalid query may cause influx-prompt to crash.

```
Welcome! Open an issue here: https://github.com/RPing/influx-prompt/issues
admin> select mean("replicas_available") from kubernetes_daemonset group by "kubernetes_cluster", "daemonset_name";
Traceback (most recent call last):
  File "/usr/local/bin/influx-prompt", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.9/site-packages/influx_prompt/main.py", line 139, in cli
    influx_prompt.run_cli()
  File "/usr/local/lib/python3.9/site-packages/influx_prompt/main.py", line 91, in run_cli
    arr = json_to_tabular_result(result)
  File "/usr/local/lib/python3.9/site-packages/influx_prompt/tabular.py", line 25, in json_to_tabular_result
    for series in series_list:
TypeError: 'NoneType' object is not iterable
```

The (deserialized) JSON payload returned from Influx is:
```
{'results': [{'statement_id': 0}]}
```

Influx client 1.8 handles this gracefully.